### PR TITLE
Python 3 support

### DIFF
--- a/pycrunch/cubes.py
+++ b/pycrunch/cubes.py
@@ -1,3 +1,5 @@
+import six
+
 from pycrunch import elements
 
 
@@ -14,7 +16,7 @@ def fetch_cube(dataset, dimensions, weight=None, **measures):
         if isinstance(d, dict):
             # This is already a Crunch expression.
             dims.append(d)
-        elif isinstance(d, basestring):
+        elif isinstance(d, six.string_types):
             ref = {'variable': d}
             # A URL of a variable entity. GET it to find its type.
             v = dataset.session.get(d).payload

--- a/pycrunch/elements.py
+++ b/pycrunch/elements.py
@@ -95,7 +95,10 @@ elements = {}
 def parse_element(session, j):
     """Recursively replace dict with appropriate subclasses of JSONObjects."""
     if isinstance(j, dict):
-        j = dict((k, parse_element(session, v)) for k, v in j.iteritems())
+        j = dict(
+            (k, parse_element(session, v))
+            for k, v in six.iteritems(j)
+        )
 
         elem = j.get("element", None)
         if elem in elements:

--- a/pycrunch/elements.py
+++ b/pycrunch/elements.py
@@ -23,6 +23,8 @@ being parsed into an instance of Foo, rather than a bare JSONObject.
 
 import json
 
+import six
+
 from pycrunch import lemonpy
 
 omitted = object()
@@ -149,21 +151,21 @@ class Document(Element):
     def post(self, data, *args, **kwargs):
         kwargs.setdefault('headers', {})
         kwargs["headers"].setdefault("Content-Type", "application/json")
-        if not isinstance(data, basestring):
+        if not isinstance(data, six.string_types):
             data = json.dumps(data)
         return self.session.post(self.self, data, *args, **kwargs)
 
     def put(self, data, *args, **kwargs):
         kwargs.setdefault('headers', {})
         kwargs["headers"].setdefault("Content-Type", "application/json")
-        if not isinstance(data, basestring):
+        if not isinstance(data, six.string_types):
             data = json.dumps(data)
         return self.session.put(self.self, data, *args, **kwargs)
 
     def patch(self, data, *args, **kwargs):
         kwargs.setdefault('headers', {})
         kwargs["headers"].setdefault("Content-Type", "application/json")
-        if not isinstance(data, basestring):
+        if not isinstance(data, six.string_types):
             data = json.dumps(data)
         return self.session.patch(self.self, data, *args, **kwargs)
 

--- a/pycrunch/elements.py
+++ b/pycrunch/elements.py
@@ -74,10 +74,9 @@ class ElementMeta(type):
         return new_type
 
 
+@six.add_metaclass(ElementMeta)
 class Element(JSONObject):
     """A base class for JSON objects classified by an 'element' member."""
-
-    __metaclass__ = ElementMeta
 
     def __init__(__this__, session, **members):
         __this__.session = session

--- a/pycrunch/importing.py
+++ b/pycrunch/importing.py
@@ -1,7 +1,7 @@
-from cStringIO import StringIO
 import mimetypes
 import os
 import time
+import io
 
 from pycrunch import shoji
 
@@ -41,7 +41,8 @@ class Importer(object):
         """Append the given string of CSV data to the dataset. Return its Batch."""
         if filename is None:
             filename = 'upload.csv'
-        source_url = self.add_source(ds, filename, StringIO(csv_string), "text/csv")
+        fp = io.BytesIO(csv_string)
+        source_url = self.add_source(ds, filename, fp, "text/csv")
         return self.create_batch_from_source(ds, source_url)
 
     def append_stream(self, ds, fp, filename=None, mimetype=None):

--- a/pycrunch/importing.py
+++ b/pycrunch/importing.py
@@ -3,6 +3,8 @@ import os
 import time
 import io
 
+import six
+
 from pycrunch import shoji
 
 
@@ -134,7 +136,7 @@ def place(dataset, key, ids, data):
 
     On success, this returns None, otherwise, an error is raised.
     """
-    if isinstance(key, basestring):
+    if isinstance(key, six.string_types):
         key = {"variable": key}
     elif isinstance(key, dict):
         pass

--- a/pycrunch/lemonpy.py
+++ b/pycrunch/lemonpy.py
@@ -1,5 +1,6 @@
 import logging
-import urlparse
+
+from six.moves import urllib
 
 import requests
 
@@ -129,7 +130,7 @@ class URL(str):
         return str.__new__(cls, value)
 
     def __init__(self, value, base):
-        base, frag = urlparse.urldefrag(base)
+        base, frag = urllib.parse.urldefrag(base)
         self.base = base
 
     @property
@@ -139,8 +140,8 @@ class URL(str):
 
     def relative_to(self, base):
         """Return self, relative to the given absolute base."""
-        base = urlparse.urlparse(base)
-        new = urlparse.urlparse(self.absolute)
+        base = urllib.parse.urlparse(base)
+        new = urllib.parse.urlparse(self.absolute)
 
         if base.scheme != new.scheme or base.netloc != new.netloc:
             return self.absolute
@@ -156,5 +157,5 @@ class URL(str):
         new_path = (['..'] * len(base_path)) + new_path
         new_path = '/'.join(new_path)
 
-        return urlparse.urlunparse(("", "", new_path,
+        return urllib.parse.urlunparse(("", "", new_path,
                                     new.params, new.query, new.fragment))

--- a/pycrunch/lemonpy.py
+++ b/pycrunch/lemonpy.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import logging
 
 from six.moves import urllib
@@ -69,7 +71,7 @@ class ResponseHandler(object):
             return handler(r)
 
         # If that fails, look for a Nxx code
-        handler = getattr(self, "status_%dxx" % (code / 100), None)
+        handler = getattr(self, "status_%dxx" % (code // 100), None)
         if handler is not None:
             return handler(r)
 

--- a/pycrunch/lemonpy.py
+++ b/pycrunch/lemonpy.py
@@ -88,11 +88,8 @@ class ResponseHandler(object):
         have to examine the Response directly to determine its payload.
         """
         ct = r.headers.get("Content-Type").split(";", 1)[0]
-        parser = self.parsers.get(ct, None)
-        if parser is None:
-            r.payload = None
-        else:
-            r.payload = parser(self.session, r)
+        parser = self.parsers.get(ct)
+        r.payload = parser(self.session, r) if parser else None
 
     def status_2xx(self, r):
         self.parse_payload(r)

--- a/pycrunch/shoji.py
+++ b/pycrunch/shoji.py
@@ -6,6 +6,8 @@ for the latest Shoji specification.
 
 import json
 
+import six
+
 from pycrunch import elements
 from pycrunch.lemonpy import URL
 
@@ -66,7 +68,7 @@ class Index(elements.JSONObject):
         members = dict(
             (URL(entity_url, catalog_url),
              None if tup is None else Tuple(session, entity_url, **tup))
-            for entity_url, tup in members.iteritems()
+            for entity_url, tup in six.iteritems(members)
         )
         super(Index, self).__init__(**members)
 

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,24 @@
 # coding: utf-8
 
 import os
+import io
+
 thisdir = os.path.abspath(os.path.dirname(__file__))
 
 from setuptools import setup, find_packages
 
-version = open(os.path.join(thisdir, 'version.txt'), 'rb').read().strip()
+version_fn = os.path.join(thisdir, 'version.txt')
+with io.open(version_fn, encoding='utf-8') as f:
+    version = f.read().strip()
 
 
 def get_long_desc():
     root_dir = os.path.dirname(__file__)
     if not root_dir:
         root_dir = '.'
-    return open(os.path.join(root_dir, 'README.md')).read()
+    readme_fn = os.path.join(root_dir, 'README.md')
+    with io.open(readme_fn, encoding='utf-8') as stream:
+        return stream.read()
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     license='LGPL',
     install_requires=[
         'requests>=2.3.0',
+        'six',
     ],
     tests_require=[
         'nose>=1.1.2',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_long_desc():
         return stream.read()
 
 
-setup(
+setup_params = dict(
     name='pycrunch',
     version=version,
     description="Crunch.io Client Library",
@@ -53,3 +53,6 @@ setup(
     zip_safe=True,
     entry_points={},
 )
+
+if __name__ == '__main__':
+    setup(**setup_params)


### PR DESCRIPTION
Using six enables single codebase Python 2 and Python 3 support. These changes enable the examples in the README to execute on Python 3.