### PR TITLE
CSV support

### DIFF
--- a/pycrunch/csv.py
+++ b/pycrunch/csv.py
@@ -6,7 +6,7 @@ import csv
 import six
 
 
-class CSVLineGenerator:
+class CSVLineGenerator(object):
     r"""
     Apply csv writer .write operations to individual rows.
 

--- a/pycrunch/csv.py
+++ b/pycrunch/csv.py
@@ -1,0 +1,95 @@
+from __future__ import absolute_import
+
+import re
+import csv
+
+import six
+
+
+class CSVLineGenerator:
+    r"""
+    Apply csv writer .write operations to individual rows.
+
+    >>> gen = CSVLineGenerator()
+
+    >>> rows = [
+    ...     ('id', 'val', 'val2'),
+    ...     (1, 2),
+    ...     (2, -1, None),
+    ...     (3, None, "foo"),
+    ...     (4, "", "bar"),
+    ... ]
+    >>> out = six.moves.map(gen.as_csv, rows)
+    >>> next(out)
+    '"id","val","val2"\n'
+    >>> next(out)
+    '1,2\n'
+
+    None values are rendered as empty strings
+
+    >>> next(out)
+    '2,-1,""\n'
+    >>> next(out)
+    '3,"","foo"\n'
+    """
+    def __init__(self, **writer_args):
+        writer_args.setdefault('quoting', csv.QUOTE_NONNUMERIC)
+        writer_args.setdefault('lineterminator', '\n')
+        self.writer = csv.writer(self, **writer_args)
+
+    def as_csv(self, row):
+        self.writer.writerow(row)
+        return vars(self).pop('last_write')
+
+    def write(self, line):
+        self.last_write = line
+
+
+class NoneAsEmptyLineGenerator(CSVLineGenerator):
+    r"""
+    Support for preventing None values from being rendered as
+    empty strings.
+
+    >>> gen = CrunchLineGenerator()
+
+    >>> rows = [
+    ...     ('id', 'val', 'val2'),
+    ...     (1, 2),
+    ...     (2, -1, None),
+    ...     (3, None, "foo"),
+    ...     (4, "", "bar"),
+    ... ]
+    >>> out = six.moves.map(gen.as_csv, rows)
+    >>> next(out)
+    '"id","val","val2"\n'
+    >>> next(out)
+    '1,2\n'
+
+    None values are rendered as null cells
+
+    >>> next(out)
+    '2,-1,\n'
+    >>> next(out)
+    '3,,"foo"\n'
+
+    Empty strings are still rendered as empty strings
+
+    >>> next(out)
+    '4,"","bar"\n'
+    """
+
+    sentinel = "CSV_SENTINEL_NONE"
+
+    def as_csv(self, row):
+        row = list(six.moves.map(self._inject_sentinel, row))
+        line = super(NoneAsEmptyLineGenerator, self).as_csv(row)
+        return self.remove_sentinel(line)
+
+    def _inject_sentinel(self, cell):
+        if cell is None:
+            return self.sentinel
+        return cell
+
+    def remove_sentinel(self, row):
+        pattern = '"' + re.escape(self.sentinel) + '"'
+        return re.sub(pattern, "", row)

--- a/pycrunch/csv.py
+++ b/pycrunch/csv.py
@@ -19,7 +19,7 @@ class CSVLineGenerator:
     ...     (3, None, "foo"),
     ...     (4, "", "bar"),
     ... ]
-    >>> out = six.moves.map(gen.as_csv, rows)
+    >>> out = gen.process(rows)
     >>> next(out)
     '"id","val","val2"\n'
     >>> next(out)
@@ -44,6 +44,9 @@ class CSVLineGenerator:
     def write(self, line):
         self.last_write = line
 
+    def process(self, rows):
+        return six.moves.map(self.as_csv, rows)
+
 
 class NoneAsEmptyLineGenerator(CSVLineGenerator):
     r"""
@@ -59,7 +62,7 @@ class NoneAsEmptyLineGenerator(CSVLineGenerator):
     ...     (3, None, "foo"),
     ...     (4, "", "bar"),
     ... ]
-    >>> out = six.moves.map(gen.as_csv, rows)
+    >>> out = gen.process(rows)
     >>> next(out)
     '"id","val","val2"\n'
     >>> next(out)

--- a/pycrunch/importing.py
+++ b/pycrunch/importing.py
@@ -5,7 +5,8 @@ import io
 
 import six
 
-from pycrunch import shoji
+from . import shoji
+from . import csv
 
 
 class Importer(object):
@@ -153,3 +154,27 @@ def place(dataset, key, ids, data):
         },
         "data": data
     })
+
+
+def post_rows(ds, rows):
+    """
+    POST the rows to the ds batches. Rows should be an iterable
+    of lists of cells.
+    """
+    gen = csv.NoneAsEmptyLineGenerator()
+    lines = six.moves.map(gen.as_csv, rows)
+    return post_lines(ds, lines)
+
+
+def post_lines(ds, lines):
+    """
+    POST the CSV lines to the ds batches. Lines should be an
+    iterable of text CSV lines.
+    """
+    encoded = (line.encode('utf-8') for line in lines)
+    data = b''.join(encoded)
+    content_type = 'application/csv'
+    filename = 'content.csv'
+    file = filename, data, content_type
+    files = dict(file=file)
+    ds.session.post(ds.batches.self, files=files)

--- a/pycrunch/importing.py
+++ b/pycrunch/importing.py
@@ -162,8 +162,7 @@ def post_rows(ds, rows):
     of lists of cells.
     """
     gen = csv.NoneAsEmptyLineGenerator()
-    lines = six.moves.map(gen.as_csv, rows)
-    return post_lines(ds, lines)
+    return post_lines(ds, gen.process(rows))
 
 
 def post_lines(ds, lines):


### PR DESCRIPTION
This PR implements the CSV processing portion of the batch upload API. It exposes two new functions `post_rows` and `post_lines` which will take rows of data and post them to the batches endpoint of a dataset.

This functionality necessarily involves some processing of values to ensure the CSV conforms to the expectation by Crunch for numeric and empty fields.