### PR TITLE
None as no data always

### DIFF
--- a/pycrunch/csvlib.py
+++ b/pycrunch/csvlib.py
@@ -14,18 +14,17 @@ def rows_as_csv_file(rows):
     # and a .read() of it (like requests.post will do) does not make a copy.
     out = six.BytesIO()
 
-    if True:
-        sentinel = "__CSV_SENTINEL_NONE__"
+    sentinel = "__CSV_SENTINEL_NONE__"
 
-        class EphemeralWriter():
-            def write(self, line):
-                line = line.replace('"' + sentinel + '"', "")
-                out.write(line.encode('utf-8'))
-        pipe = EphemeralWriter()
+    class EphemeralWriter():
+        def write(self, line):
+            line = line.replace('"' + sentinel + '"', "")
+            out.write(line.encode('utf-8'))
+    pipe = EphemeralWriter()
 
-        writer = csv.writer(pipe, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
-        for row in rows:
-            writer.writerow([sentinel if cell is None else cell for cell in row])
+    writer = csv.writer(pipe, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
+    for row in rows:
+        writer.writerow([sentinel if cell is None else cell for cell in row])
 
     out.seek(0)
 

--- a/pycrunch/csvlib.py
+++ b/pycrunch/csvlib.py
@@ -2,20 +2,19 @@ import csv
 import six
 
 
-def rows_as_csv_file(rows, none_as_no_data=True):
+def rows_as_csv_file(rows):
     """Return rows (iterable of lists of cells) as an open CSV file.
 
-    If none_as_no_data is True (the default), then any cells in the given
+    Any cells in the given
     rows which contain None will be emitted as an empty cell in the CSV
     (nothing between the commas), which Crunch interprets as {"?": -1},
-    the "No Data" system missing value. If False, None values are emitted
-    normally by the Python csv library, which means as (quoted) empty strings.
+    the "No Data" system missing value.
     """
     # Write to a BytesIO because it joins encoded lines as we go
     # and a .read() of it (like requests.post will do) does not make a copy.
     out = six.BytesIO()
 
-    if none_as_no_data:
+    if True:
         sentinel = "__CSV_SENTINEL_NONE__"
 
         class EphemeralWriter():
@@ -27,10 +26,6 @@ def rows_as_csv_file(rows, none_as_no_data=True):
         writer = csv.writer(pipe, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
         for row in rows:
             writer.writerow([sentinel if cell is None else cell for cell in row])
-    else:
-        writer = csv.writer(out, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
-        for row in rows:
-            writer.writerow(row)
 
     out.seek(0)
 


### PR DESCRIPTION
May I suggest removing the parameter from rows_as_csv_file? In my proposed implementation, I had separated the behavior that allowed None to be rendered as the empty string only to keep encapsulated the Crunch-specific behavior from the incremental writing behavior. Since that encapsulation had unacceptable performance degradation and because the current implementation doesn't keep that behavior separate, the usage that generates Crunch-incompatible CSV isn't of any value to us, so I recommend dropping it for simplicity.