### PR TITLE
Separate function for rows_as_csv_file into two alternate implementations

### DIFF
--- a/pycrunch/csvlib.py
+++ b/pycrunch/csvlib.py
@@ -1,36 +1,58 @@
+"""
+CSV support for Crunch.
+
+The two functions, rows_as_csv_file* should be kept in sync.
+The differing behavior cannot be factored out due to
+the underlying stdlib csv module implementation and
+performance characteristics of Python function calls.
+"""
+
 import csv
 import six
 
 
-def rows_as_csv_file(rows, none_as_no_data=True):
+def rows_as_csv_file(rows):
     """Return rows (iterable of lists of cells) as an open CSV file.
 
-    If none_as_no_data is True (the default), then any cells in the given
+    Any cells in the given
     rows which contain None will be emitted as an empty cell in the CSV
     (nothing between the commas), which Crunch interprets as {"?": -1},
-    the "No Data" system missing value. If False, None values are emitted
+    the "No Data" system missing value.
+    """
+    # Write to a BytesIO because it joins encoded lines as we go
+    # and a .read() of it (like requests.post will do) does not make a copy.
+    out = six.BytesIO()
+
+    sentinel = "__CSV_SENTINEL_NONE__"
+
+    class EphemeralWriter():
+        def write(self, line):
+            line = line.replace('"' + sentinel + '"', "")
+            out.write(line.encode('utf-8'))
+    pipe = EphemeralWriter()
+
+    writer = csv.writer(pipe, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
+    for row in rows:
+        writer.writerow([sentinel if cell is None else cell for cell in row])
+
+    out.seek(0)
+
+    return out
+
+def rows_as_csv_file_clean(rows):
+    """Return rows (iterable of lists of cells) as an open CSV file.
+
+    Duplicate of rows_as_csv_file except
+    None values are emitted
     normally by the Python csv library, which means as (quoted) empty strings.
     """
     # Write to a BytesIO because it joins encoded lines as we go
     # and a .read() of it (like requests.post will do) does not make a copy.
     out = six.BytesIO()
 
-    if none_as_no_data:
-        sentinel = "__CSV_SENTINEL_NONE__"
-
-        class EphemeralWriter():
-            def write(self, line):
-                line = line.replace('"' + sentinel + '"', "")
-                out.write(line.encode('utf-8'))
-        pipe = EphemeralWriter()
-
-        writer = csv.writer(pipe, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
-        for row in rows:
-            writer.writerow([sentinel if cell is None else cell for cell in row])
-    else:
-        writer = csv.writer(out, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
-        for row in rows:
-            writer.writerow(row)
+    writer = csv.writer(out, quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
+    for row in rows:
+        writer.writerow(row)
 
     out.seek(0)
 

--- a/pycrunch/csvlib.py
+++ b/pycrunch/csvlib.py
@@ -45,6 +45,9 @@ def rows_as_csv_file_clean(rows):
     Duplicate of rows_as_csv_file except
     None values are emitted
     normally by the Python csv library, which means as (quoted) empty strings.
+    Use this function if the rows contain no None values or
+    if None values are only used for "text" types and the empty
+    string is a suitable representation for those values.
     """
     # Write to a BytesIO because it joins encoded lines as we go
     # and a .read() of it (like requests.post will do) does not make a copy.


### PR DESCRIPTION
Adds documentation as to why the two versions exist and when each is to be used.

This PR implements the suggestion I made in PR #6 to have separate functions. I find this implementation preferable because when reviewing the code and trying to comprehend what it accomplishes, the amount of code that has to be considered is minimized. The programmer can identify which function is relevant and focus on its implementation without also maintaining a cognitive context for a boolean value which was or wasn't passed in. This technique avoids the [boolean parameter anti-pattern](http://blog.iannelson.systems/back-to-basics-on-the-use-and-abuse-of-the-humble-boolean/).

I provide this alternative implementation for your consideration. Accept PR #6, or this one, or neither to your taste.