### PR TITLE
add a basic tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27, py33, py34, py35, py36
+
+[testenv]
+commands =
+    {envpython} setup.py test


### PR DESCRIPTION
Adds a really basic `tox.ini`, so I can easily test my next few patches against both python 2 & 3.

Example:

```
(env-pycrunch) $  pip install tox
(env-pycrunch) $  tox -e py27
13 passed in 2.61 seconds
```

Note: I'm seeing periodic test failures (unrelated to this change). For example:

```
Expected call: post('http://host.com/catalog', '{\n    "element": "shoji:entity",\n    "somedata": 1,\n    "body": {}\n}', headers={'Content-Type': 'application/json'})
  Actual call: post('http://host.com/catalog', '{\n    "body": {},\n    "somedata": 1,\n    "element": "shoji:entity"\n}', headers={'Content-Type': 'application/json'})
``` 

I suspect (but could be wrong), that json serialization with `sort_keys=True` could eliminate some of these nondeterministic test failures.

Either way, those test failures are unrelated to this patch.