### PR TITLE
increase csvlib test coverage from 68% to 100%

### DIFF
--- a/pycrunch/tests/test_csvlib.py
+++ b/pycrunch/tests/test_csvlib.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals
 
-import io
-import csv
 from unittest import TestCase
 
 import six
@@ -23,19 +21,14 @@ class TestCSV(TestCase):
         res = csvlib.rows_as_csv_file([['foo']])
         assert isinstance(next(res), six.binary_type)
 
-    def test_stdlib_unicode(self):
-        # Demonstrate how one might go about writing unicode to a CSV
-        # on Python 2 and Python 3.
+    def test_rows_as_csv_file(self):
+        # None should be emitted as an empty cell (unquoted)
+        rows = [[0, 1, None, "bananas"]]
+        fp = csvlib.rows_as_csv_file(rows)
+        self.assertEqual(fp.read(), b'0,1,,"bananas"\n')
 
-        # See http://python3porting.com/problems.html#csv-api-changes
-        # for more details.
-        out = io.StringIO() if six.PY3 else io.BytesIO()
-        w = csv.writer(out)
-        row = ['☃']
-        row = [
-            cell.encode('utf-8')
-                if six.PY2 and isinstance(cell, six.text_type)
-                else cell
-            for cell in row
-        ]
-        w.writerow(row)
+    def test_rows_as_csv_file_clean(self):
+        # None should be emitted as an empty string (quoted)
+        rows = [[0, 1, None, "bananas"]]
+        fp = csvlib.rows_as_csv_file_clean(rows)
+        self.assertEqual(fp.read(), b'0,1,"","bananas"\n')


### PR DESCRIPTION
Adds a couple simple tests that brings the test coverage for csvlib up from 68% to 100%.

- I also deleted a test that appears to just mimic the impl from csvlib. Looks to me like it was a WIP test that has lived longer than intended. As always, I could be wrong... happy to respin, minus that change. 