### PR TITLE
Remove async parameter. Fixes #41.

### DIFF
--- a/src/pycrunch/importing.py
+++ b/src/pycrunch/importing.py
@@ -74,7 +74,7 @@ class Importer(object):
 
         return new_source_url
 
-    def create_batch_from_source(self, ds, source_url, workflow=None, async=False,
+    def create_batch_from_source(self, ds, source_url, workflow=None,
                                  savepoint=True, autorollback=True):
         """Create and return a Batch on the given dataset for the given source."""
         batch = shoji.Entity(ds.session, body={


### PR DESCRIPTION
After a quick review, I couldn't find anything that depends on this async parameter. Can we remove it? I could devise a more complicated way of retaining this parameter (either positional or keyword or both), but it seems not worth the trouble if nothing is using it.

I haven't been able to test pycrunch on Python 3.7 due to numpy/numpy#10500.