### PR TITLE
Ensure that .by() works with any hashable attribute (in Python 3)

### DIFF
--- a/src/pycrunch/shoji.py
+++ b/src/pycrunch/shoji.py
@@ -187,11 +187,11 @@ class CreateMixin(object):
         copied to the output keys. Due to restrictions on Python dicts,
         specifying attrs which are not hashable will raise an error.
         """
-        return elements.JSONObject(**dict(
+        return elements.JSONObject(
             (tupl[attr], tupl)
             for tupl in six.itervalues(self.index)
             if attr in tupl
-        ))
+        )
 
 
 class Catalog(elements.Document, CreateMixin):

--- a/tests/test_shoji.py
+++ b/tests/test_shoji.py
@@ -9,7 +9,7 @@ import sys
 from requests import Response
 
 from pycrunch.progress import DefaultProgressTracking, SimpleTextBarProgressTracking
-from pycrunch.shoji import Catalog, TaskProgressTimeoutError, TaskError, Index, Order, Entity
+from pycrunch.shoji import Catalog, CreateMixin, TaskProgressTimeoutError, TaskError, Index, Order, Entity
 from pycrunch.lemonpy import URL
 
 
@@ -334,3 +334,15 @@ class TestEntities(TestCase):
         })
         self.assertTrue(isinstance(ent.index, Index))
         self.assertEqual(ent.by('key')['val1'].entity_url, 'url1/')
+
+
+class TestCreateMixin(TestCase):
+
+    def test_by_integer_keys(self):
+        tuple1 = {'id': 1, 'name': 'A'}
+        tuple2 = {'id': 2, 'name': 'B'}
+
+        obj = CreateMixin()
+        obj.index = {'url1/': tuple1, 'url2/': tuple2}
+
+        self.assertEqual(obj.by('id'), {1: tuple1, 2: tuple2})


### PR DESCRIPTION
In Python 3 a dictionary can only be unpacked in a function call if its keys are all strings, so previously .by() would fail for any non-string attribute, not just any non-hashable attribute.

Using a comprehension to populate the JSONObject avoids this problem, and should be more efficient too.