### PR TITLE
Fetch cube dims by Subvariable URL

### DIFF
--- a/src/pycrunch/cubes.py
+++ b/src/pycrunch/cubes.py
@@ -36,7 +36,7 @@ def fetch_cube(dataset, dimensions, weight=None, filter=None, **measures):
     >>> fetch_cube(dataset, dimensions, weight=weight, filter=filter, count=count)
 
     """
-    dims = prepare_dims(dataset, dimensions)
+    dims = DimensionsPreparer(dataset).prepare_dimensions(dimensions)
     cube_query = elements.JSONObject(dimensions=dims, measures=measures)
 
     if weight is not None:
@@ -52,49 +52,92 @@ def fetch_cube(dataset, dimensions, weight=None, filter=None, **measures):
     ).payload
 
 
-def prepare_dims(dataset, dimensions):
-    dims = []
-    variables_by_alias = dataset.variables.by('alias')
-    variables_by_name = dataset.variables.by('name')
+class DimensionsPreparer(object):
 
-    for dim in dimensions:
-        if isinstance(dim, dict):
-            # This is already a Crunch expression.
-            dims.append(dim)
-        elif isinstance(dim, six.string_types):
-            if dim in dataset.variables.index:
-                # When URL is provided, fetch variable from index
-                dim = dataset.variables.index[dim]
-            elif dim in variables_by_alias:
-                dim = variables_by_alias[dim]
-            elif dim in variables_by_name:
-                dim = variables_by_name[dim]
+    """Implement basic preparation of requested cube dimensions.
+
+    Cube dimensions can be requested in different forms:
+
+    1. Crunch expressions
+    2. Variable URLs (or full Subvariable URLs)
+    3. Variable Names
+    4. Variable Aliases
+
+    If Crunch expression is provided, no action needs to be taken, because the
+    cube api can handle this notation. In the case of URLs, names, or aliases,
+    the conversion needs to be done (to crunch expression), in order for cube
+    api to be able to handle it.
+    """
+
+    def __init__(self, dataset):
+        self._dataset = dataset
+        self._variables_by_alias = dataset.variables.by('alias')
+        self._variables_by_name = dataset.variables.by('name')
+
+    def prepare_dimensions(self, dimensions):
+        """Return list of crunch expressions for each cube dimension.
+
+        :param dimensions: Collection of cube dimensions (as Crunch
+            expressions, URLs, Names, or Aliases')
+        :type dimensions: list of strings or dicts
+        """
+
+        dims = []
+
+        for dim in dimensions:
+            if isinstance(dim, dict):
+                # This is already a Crunch expression.
+                dims.append(dim)
+            elif isinstance(dim, six.string_types):
+                dim = self.get_dimension_by_string(dim)
+                dims.extend(self.prepare_ref(dim))
             else:
-                msg = "Can't find dim {} in dataset {}".format(dim, dataset.self)
-                raise ValueError(msg)
-            dims.extend(prepare_ref(dim))
+                raise TypeError(
+                    "Dimensions must be URL strings "
+                    "or Crunch expression objects."
+                )
+
+        return dims
+
+    def get_dimension_by_string(self, dim_str):
+        """Return variable object from pycrunch dataset.
+
+        :param dim_str: String representing URL, Name, or Alias of a variable
+        """
+
+        if dim_str in self._dataset.variables.index:
+            # When URL is provided, fetch variable from index
+            return self._dataset.variables.index[dim_str]
+        elif dim_str in self._variables_by_alias:
+            return self._variables_by_alias[dim_str]
+        elif dim_str in self._variables_by_name:
+            return self._variables_by_name[dim_str]
+        elif 'subvariables/' in dim_str:
+            var_url = dim_str.split('subvariables/')[0]
+            variable = self._dataset.variables.index[var_url]
+            return variable.entity.subvariables.index[dim_str]
+
+        raise ValueError("Can't find variable {} in dataset {}".format(
+            dim_str, self._dataset.self
+        ))
+
+
+    @staticmethod
+    def prepare_ref(dim):
+        ref = {'variable': dim.entity_url}
+        if dim.type == "numeric":
+            ref = [{"function": "bin", "args": [ref]}]
+        elif dim.type == "datetime":
+            rollup_res = dim.rollup_resolution
+            ref = [{"function": "rollup", "args": [ref, {"value": rollup_res}]}]
+        elif dim.type == "categorical_array":
+            ref = [{"each": dim.entity_url}, ref]
+        elif dim.type == "multiple_response":
+            ref = [{"each": dim.entity_url}, {"function": "as_selected", "args": [ref]}]
         else:
-            msg = "dimensions must be URL strings or Crunch expression objects."
-            raise TypeError(msg)
+            ref = [ref]
 
-    return dims
-
-
-def prepare_ref(dim):
-    ref = {'variable': dim.entity_url}
-    if dim.type == "numeric":
-        ref = [{"function": "bin", "args": [ref]}]
-    elif dim.type == "datetime":
-        rollup_res = dim.rollup_resolution
-        ref = [{"function": "rollup", "args": [ref, {"value": rollup_res}]}]
-    elif dim.type == "categorical_array":
-        ref = [{"each": dim.entity_url}, ref]
-    elif dim.type == "multiple_response":
-        ref = [{"each": dim.entity_url}, {"function": "as_selected", "args": [ref]}]
-    else:
-        ref = [ref]
-
-    return ref
+        return ref
 
 
 def count(*args):

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -1,13 +1,21 @@
-from mock import Mock
+from mock import Mock, patch
 import pytest
 
-from pycrunch.cubes import prepare_ref
+from pycrunch.cubes import DimensionsPreparer
 
 
 def test_prepare_ref(prepare_ref_fixture):
     dim, expected = prepare_ref_fixture
-    actual = prepare_ref(dim)
+    actual = DimensionsPreparer.prepare_ref(dim)
     assert actual == expected
+
+
+def test_get_dimension_by_string(dimension_string_fixture):
+    dim_str, preparer, dim = dimension_string_fixture
+    assert preparer.get_dimension_by_string(dim_str) == dim
+
+
+# fixtures -----------------------------------------------------------
 
 
 @pytest.fixture(params=[
@@ -23,3 +31,30 @@ def prepare_ref_fixture(request):
     dim.type = dimension_type
     dim.rollup_resolution = rollup
     return dim, expected
+
+@pytest.fixture(params=[
+    ('fake_url', 'URL', Mock(), None),
+    ('fake_url/subvariables/fake_id', 'URL_SUBVAR', Mock(), Mock()),
+    ('fake_alias', 'ALIAS', Mock(), None),
+    ('fake_alias', 'NAME', Mock(), None),
+])
+def dimension_string_fixture(request):
+    dim_str, str_type, dim, subvar = request.param
+    preparer = DimensionsPreparer(Mock())
+    preparer._dataset.variables.index = dict()
+    preparer._variables_by_alias = dict()
+    preparer._variables_by_name = dict()
+    if str_type == 'URL':
+        preparer._dataset.variables.index[dim_str] = dim
+    elif str_type == 'URL_SUBVAR':
+        var_url = dim_str.split('subvariables/')[0]
+        preparer._dataset.variables.index[var_url] = dim
+        preparer._dataset.variables.index[
+            var_url
+        ].entity.subvariables.index = {dim_str: subvar}
+        dim = subvar
+    elif str_type == 'ALIAS':
+        preparer._variables_by_alias[dim_str] = dim
+    elif str_type == 'NAME':
+        preparer._variables_by_name[dim_str] = dim
+    return dim_str, preparer, dim


### PR DESCRIPTION
* Refactor fetch_cube.py
* Write more unit tests for supporting dimensions handling
* For URLs with the '/subvariables/' substring, extract the variable and
  subvariable parts, and fetch the correct subvariable