### PR TITLE
Don't pretty-print JSON payloads when posting to a catalog

### DIFF
--- a/src/pycrunch/shoji.py
+++ b/src/pycrunch/shoji.py
@@ -151,7 +151,7 @@ class CreateMixin(object):
         elif isinstance(entity, dict) and not isinstance(entity, elements.Document):
             entity = Entity(self.session, **entity)
 
-        response = self.post(data=json.dumps(entity))
+        response = self.post(data=json.dumps(entity, indent=None, separators=(',', ':')))
         if response.history:
             # Coming from a redirect
             seeother = [r for r in response.history if r.status_code == 303]

--- a/src/pycrunch/shoji.py
+++ b/src/pycrunch/shoji.py
@@ -151,7 +151,7 @@ class CreateMixin(object):
         elif isinstance(entity, dict) and not isinstance(entity, elements.Document):
             entity = Entity(self.session, **entity)
 
-        response = self.post(data=entity.json)
+        response = self.post(data=json.dumps(entity))
         if response.history:
             # Coming from a redirect
             seeother = [r for r in response.history if r.status_code == 303]

--- a/tests/test_shoji.py
+++ b/tests/test_shoji.py
@@ -26,7 +26,7 @@ class TestShojiCreation(TestCase):
         c.create({'somedata': 1})
         sess.post.assert_called_once_with(
             'http://host.com/catalog',
-            json.dumps({"somedata": 1, "body": {}, "element": "shoji:entity"}, indent=4),
+            json.dumps({"somedata": 1, "body": {}, "element": "shoji:entity"}),
             headers={'Content-Type': 'application/json'}
         )
 
@@ -36,7 +36,7 @@ class TestShojiCreation(TestCase):
         e.create({'somedata': 1})
         sess.post.assert_called_once_with(
             '/entity/url/',
-            json.dumps({"somedata": 1, "body": {}, "element": "shoji:entity"}, indent=4),
+            json.dumps({"somedata": 1, "body": {}, "element": "shoji:entity"}),
             headers={'Content-Type': 'application/json'}
         )
 

--- a/tests/test_shoji.py
+++ b/tests/test_shoji.py
@@ -26,7 +26,11 @@ class TestShojiCreation(TestCase):
         c.create({'somedata': 1})
         sess.post.assert_called_once_with(
             'http://host.com/catalog',
-            json.dumps({"somedata": 1, "body": {}, "element": "shoji:entity"}),
+            json.dumps(
+                {"somedata": 1, "body": {}, "element": "shoji:entity"},
+                indent=None,
+                separators=(',', ':'),
+            ),
             headers={'Content-Type': 'application/json'}
         )
 
@@ -36,7 +40,11 @@ class TestShojiCreation(TestCase):
         e.create({'somedata': 1})
         sess.post.assert_called_once_with(
             '/entity/url/',
-            json.dumps({"somedata": 1, "body": {}, "element": "shoji:entity"}),
+            json.dumps(
+                {"somedata": 1, "body": {}, "element": "shoji:entity"},
+                indent=None,
+                separators=(',', ':'),
+            ),
             headers={'Content-Type': 'application/json'}
         )
 


### PR DESCRIPTION
This reduces the size of the payload by more than half in some cases, and in extreme cases that can make the difference between the request succeeding or failing.