### PR TITLE
Remove url query strings when calling Document.post method

### DIFF
--- a/src/pycrunch/elements.py
+++ b/src/pycrunch/elements.py
@@ -34,9 +34,10 @@ from .version import __version__
 try:
     # Python 2
     from urllib import urlencode, quote
+    from urlparse import urlunparse, urlparse
 except ImportError:
     # Python 3
-    from urllib.parse import urlencode, quote
+    from urllib.parse import urlencode, quote, urlunparse, urlparse
 
 omitted = object()
 
@@ -232,7 +233,9 @@ class Document(Element):
         kwargs["headers"].setdefault("Content-Type", "application/json")
         if not isinstance(data, six.string_types):
             data = json.dumps(data)
-        return self.session.post(self.self, data, *args, **kwargs)
+        # Remove any existing params, such as "limit=0"
+        url = urlunparse(urlparse(self.self)._replace(query=""))
+        return self.session.post(url, data, *args, **kwargs)
 
     def put(self, data, *args, **kwargs):
         kwargs.setdefault('headers', {})

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -208,6 +208,16 @@ class TestDocument(TestCase):
             headers={'Content-Type': 'application/json'}
         )
 
+    def test_post_with_params(self):
+        session_mock = mock.MagicMock()
+        person = self.Person(session=session_mock, self='some uri?param_1=a&param_2=b')
+        person.post(data={'age': 10})
+        session_mock.post.assert_called_once_with(
+            'some uri',
+            '{"age": 10}',
+            headers={'Content-Type': 'application/json'}
+        )
+
     def test_put(self):
         session_mock = mock.MagicMock()
         person = self.Person(session=session_mock, self='some uri')


### PR DESCRIPTION
When a `Document` (doc) object's `follow` method is  called with a qs , then url (self.self) will contain the qs.
If the doc's `post` method is then called, the url still contains the qs and a `404` error is thrown.
This merge request removes any lingering qs from the url.