### PR TITLE
Return payload only on valid response 

### DIFF
--- a/src/pycrunch/elements.py
+++ b/src/pycrunch/elements.py
@@ -22,23 +22,24 @@ being parsed into an instance of Foo, rather than a bare JSONObject.
 """
 
 import json
-
-import six
 import warnings
 
+import six
 from requests.utils import get_environ_proxies
 
 from pycrunch import lemonpy
 from pycrunch.progress import DefaultProgressTracking
+
 from .version import __version__
 
 try:
     # Python 2
-    from urllib import urlencode, quote
+    from urllib import quote, urlencode
+
     from urlparse import urlparse
 except ImportError:
     # Python 3
-    from urllib.parse import urlencode, quote, urlparse
+    from urllib.parse import quote, urlencode, urlparse
 
 omitted = object()
 
@@ -153,7 +154,7 @@ class Document(Element):
                 response = self.session.get(url, headers=headers)
                 if response.status_code not in {401}:
                     return response.payload
-                raise ValueError(response.json()["exception"][0])
+                raise ValueError("Unauthorized")
 
         raise AttributeError("%s has no attribute %s" % (self.__class__.__name__, key))
 
@@ -317,7 +318,12 @@ class ElementSession(lemonpy.Session):
     handler_class = ElementResponseHandler
 
     def __init__(
-        self, email=None, password=None, token=None, site_url=None, progress_tracking=None
+        self,
+        email=None,
+        password=None,
+        token=None,
+        site_url=None,
+        progress_tracking=None,
     ):
         if not site_url and token:
             raise ValueError("Must include a `site_url` host to connect to")

--- a/src/pycrunch/elements.py
+++ b/src/pycrunch/elements.py
@@ -150,7 +150,10 @@ class Document(Element):
             coll = self.get(collname, {})
             if key in coll:
                 url = coll[key]
-                return self.session.get(url, headers=headers).payload
+                response = self.session.get(url, headers=headers)
+                if response.status_code not in {401}:
+                    return response.payload
+                raise ValueError(response.json()["exception"][0])
 
         raise AttributeError("%s has no attribute %s" % (self.__class__.__name__, key))
 


### PR DESCRIPTION
```
{'exception': ['User must be a dataset editor'],
 'status': '401 Unauthorized',
 'traceback': ['Traceback (most recent call last):',
               '  File '
               '"/home/testrunner/testvenv3/lib64/python3.6/site-packages/cherrypy/_cprequest.py", '
               'line 670, in respond',
               '    response.body = self.handler()',
               '  File '
               '"/home/testrunner/testvenv3/lib64/python3.6/site-packages/cherrypy/lib/encoding.py", '
               'line 221, in __call__',
               '    self.body = self.oldhandler(*args, **kwargs)',
               '  File "/code/zz9/zz9lib/src/zz9lib/observe.py", line 664, in '
               'inner',
               '    return f(*args, **kwargs)',
               '  File "/code/server/src/cr/server/api/controllers/tools.py", '
               'line 668, in tracing_inner',
               '    return oldhandler(*args, **kwargs)',
               '  File "/code/server/src/cr/server/shoji.py", line 164, in '
               'shojify_inner',
               '    result = request._pre_shojify_handler(*args, **kwargs)',
               '  File '
               '"/home/testrunner/testvenv3/lib64/python3.6/site-packages/cherrypy/_cpdispatch.py", '
               'line 60, in __call__',
               '    return self.callable(*self.args, **self.kwargs)',
               '  File '
               '"/code/server/src/cr/server/api/controllers/datasets/share.py", '
               'line 90, in GET',
               '    raise cherrypy.HTTPError(401, "User must be a dataset '
               'editor")',
               "cherrypy._cperror.HTTPError: (401, 'User must be a dataset "
               "editor')",
               ''],
 'urls': {'login_url': 'http://local.crunch.io:33711/api/public/login/',
          'otp_authorize': 'http://local.crunch.io:33711/api/otp/authorize',
          'otp_login': 'http://local.crunch.io:33711/api/otp/login',
          'password_change_url': 'http://local.crunch.io:33711/api/public/password_change/',
          'password_reset_url': 'http://local.crunch.io:33711/api/public/password_reset/',
          'public_url': 'http://local.crunch.io:33711/api/public/'}}
```